### PR TITLE
Additions to support GFDL post-processed data

### DIFF
--- a/interface_scripts/projects.py
+++ b/interface_scripts/projects.py
@@ -1116,6 +1116,202 @@ class CMIP5_ETHZ(CMIP5):
 
         return os.path.join(maskdir, maskfile)
 
+
+class GFDL_UDA(Project):
+    """ @brief Class defining the specific characteristics of the CMIP5 project
+    and the data available in the GFDL Unified Data Archive. """
+    def __init__(self):
+        Project.__init__(self)
+
+        ## The names of the space separated entries in the XML-file <model> tag
+        ## lines
+        self.model_specifiers = ["project", "name", "mip", "experiment",
+                                 "ensemble", "start_year", "end_year", "dir"]
+
+        self.add_specifier['case_name'] = 'experiment'
+
+        """ Define the 'basename'-variable explicitly
+        """
+        self.basename = "GFDL_UDA"
+
+    def get_dict_key(self, model, mip, exp):
+        """ @brief Returns a unique key based on the model entries provided.
+            @param model One of the <model>-tags in the XML namelist file
+            @return A string
+
+            This function creates and returns a key used in a number of NCL
+            scripts to refer to a specific dataset, see e.g., the variable
+            'cn' in 'interface_scripts/read_data.ncl'
+        """
+        # msd = model_section_dictionary
+        msd = self.get_model_sections(model)
+        msd = self.rewrite_mip_exp(msd, mip, exp)
+
+        dict_key = "_".join([msd['project'],
+                             msd['name'],
+                             msd['mip'],
+                             msd['experiment'],
+                             msd['ensemble'],
+                             msd['start_year'],
+                             msd['end_year']])
+        return dict_key
+
+    def get_figure_file_names(self, project_info, model, mip, exp):
+        """ @brief Returns the full path used for intermediate data storage
+            @param project_info Current namelist in dictionary format
+            @param model One of the <model>-tags in the XML namelist file
+            @param variable_attributes The variable attributes
+            @return A string
+
+            This function creates and returns the full path used in a number
+            of NCL scripts to write intermediate data sets.
+        """
+        # msd = model_section_dictionary
+        msd = self.get_model_sections(model)
+        msd = self.rewrite_mip_exp(msd, mip, exp)
+
+        return "_".join([msd['project'],
+                         msd['name'],
+                         msd['mip'],
+                         msd['experiment'],
+                         msd['ensemble'],
+                         msd['start_year']]) + "-" + msd['end_year']
+
+    def get_cf_infile(self, project_info, model, field, variable, mip, exp):
+        """ @brief Returns the path to the input file used in reformat
+            @param variable Current variable
+            @param climo_dir Where processed (reformatted) input files reside
+            @param model One of the <model>-tags in the XML namelist file
+            @param field The field (see tutorial.pdf for available fields)
+            @param variable The variable
+                            (defaults to the variable in project_info)
+            @param variable_attributes The variable attributes
+            @return Two strings (input directory and input file)
+
+            This function looks for the input file to use in the
+            reformat routines
+        """
+        indata_root = self.get_data_root()
+
+        # msd = model_section_dictionary
+        msd = self.get_model_sections(model)
+        msd = self.rewrite_mip_exp(msd, mip, exp)
+
+
+#        indir = os.path.join(indata_root, msd["dir"])
+
+        variable = self.get_project_variable_name(model, variable)
+
+        indir = self.get_uda_dir(msd['dir'], msd['name'], msd['experiment'],
+                                   variable, msd['mip'], msd['ensemble'])
+
+        infile = '_'.join([variable,
+                           self.table,
+                           msd['name'],
+                           msd['experiment'],
+                           msd['ensemble']]) + '.nc'
+
+        if (not os.path.isfile(os.path.join(indir, infile))):
+            infile = '_'.join([variable,
+                               self.table,
+                               msd['name'],
+                               msd['experiment'],
+                               msd['ensemble']]) + '*.nc'
+
+        self.dmget_gfdl_files(indir, infile)
+            
+        return indir, infile
+
+    def dmget_gfdl_files(self, indir, infile):
+        """ The seems to be the need to make sure that the files 
+        are available on disk in archive despite using the /work repo
+        """
+        full_path = os.path.join(indir, infile)
+        full_path = re.sub("^/work2", "/archive/pcmdi", full_path)
+
+        os.system("dmget %s" % full_path)
+        return
+
+    def get_uda_dir(self, basedir, model_name, experiment, variable, mip, ensemble):
+        """ @brief Returns the GFDL UDA directory for the
+        collection of CMIP5 Data housed at GFDL in standard
+        DRS Syntax. """
+        
+        ModelCenters = os.walk(basedir).next()[1]
+        modelCenter = ""
+        finalPath = ""
+        freq = "mon"
+        realm = mip
+        if re.match("aero", realm):
+            realm = "aerosol"
+        while not modelCenter:
+            for center in ModelCenters:
+                models = os.walk(os.path.join(basedir, center)).next()[1]
+                if model_name in models:
+                    modelCenter = center
+        expandedPath = os.path.join(basedir, modelCenter, model_name, experiment, freq, realm, )
+        if not os.path.isdir(expandedPath):
+            error_msg = "ERROR: Unable to determine Modeling center for %s, check model name" % model_name
+            return error_msg
+        self.table = os.walk(expandedPath).next()[1][0]
+        expandedPath = os.path.join(expandedPath, str(self.table), ensemble)
+        versions = os.walk(expandedPath).next()[1]
+        versions.sort(reverse=True)
+        var_version = versions[0]
+        expandedPath = os.path.join(expandedPath, var_version, variable)
+
+        return expandedPath
+
+    def get_cf_areafile(self, project_info, model):
+        """ @brief Returns the path to the areacello file
+                   used for ocean variables
+            @param project_info Current namelist in dictionary format
+            @param model One of the <model>-tags in the XML namelist file
+            @return A string (areafile path)
+
+            This function looks for the areafile of the ocean grid
+        """
+        msd = self.get_model_sections(model)
+
+        areadir = msd["dir"]
+
+        areafile = 'areacello_fx_' + msd["name"] + "_" + msd["experiment"] + \
+                   "_r0i0p0.nc"
+
+        return os.path.join(areadir, areafile)
+
+    def get_cf_outfile(self, project_info, model, field, variable, mip, exp):
+        """ @brief Returns the output file used in the reformat routines
+            @param variable Current variable
+            @param climo_dir Where processed (reformatted) input files reside
+            @param model One of the <model>-tags in the XML namelist file
+            @param field The field (see tutorial.pdf for available fields)
+            @param variable The variable
+                            (defaults to the variable in project_info)
+            @return A string (output path)
+
+            This function specifies the output file to use in the reformat
+            routines and in climate.ncl
+        """
+
+        # msd = model_section_dictionary
+        msd = self.get_model_sections(model)
+
+        # Overide some model lines with settings from the variable attributes
+        msd = self.rewrite_mip_exp(msd, mip, exp)
+
+        outfile = '_'.join([msd['project'],
+                            msd['mip'],
+                            msd['experiment'],
+                            msd['name'],
+                            msd['ensemble'],
+                            field,
+                            variable,
+                            msd['start_year']]) + '-' + msd['end_year'] + '.nc'
+
+        return outfile
+
+
 class MiKlip(Project):
     """ @brief Follows the MiKlip directory structure for input data
                for baseline 1

--- a/reformat_scripts/GFDL/names_GFDL.dat
+++ b/reformat_scripts/GFDL/names_GFDL.dat
@@ -15,10 +15,43 @@
 ###############################################################################
 STANDARD NAME  # GFDL NAME      # VALID TYPES   # VERT  # REFERENCE           #
 ###############################################################################
+cl	       | cld_amt	| T3?,T2?z	|	| CMIP5_Amon	      |
+clt	       | cld_amt_2d     | T2?s          |       | CMIP5_Amon	      |
+clwvi	       | WP_all_clouds	| T2?s		|	| CMIP5_Amon	      |
+hfls	       | hfls		| T2?s		|	| CMIP5_Amon	      |
+hfss	       | shflx		| T2?s		|	| CMIP5_Amon	      |
+hus 	       | sphum		| T3?,T2?z	|	| CMIP5_Amon	      |
+mrro	       | #RECIP		| T2?s		| 	| CMIP5_Lmon	      |
 pr             | precip         | T2?s          |       | CMIP5_Amon          |
+prsn	       | snow_tot	| T2?s		|	| CMIP5_Amon	      |
 psl            | slp            | T2?s          |       | CMIP5_Amon          |
+rlds	       | lwdn_sfc	| T2?s		|	| CMIP5_Amon	      |
+rldscs	       | lwdn_sfc_clr	| T2?s		|	| CMIP5_Amon	      |
+rlus	       | lwup_sfc	| T2?s		|	| CMIP5_Amon	      |
+rluscs	       | lwup_sfc_clr	| T2?s		|	| CMIP5_Amon	      |
+rlut	       | olr		| T2?s		|	| CMIP5_Amon	      |
+rlutcs	       | olr_clr	| T2?s		|	| CMIP5_Amon	      |
+rsds	       | swdn_sfc	| T2?s		|	| CMIP5_Amon	      |
+rsdscs	       | swdn_sfc_clr	| T2?s		|	| CMIP5_Amon	      |
+rsdt	       | swdn_toa	| T2?s		|	| CMIP5_Amon	      |
+rsus	       | swup_sfc	| T2?s		|	| CMIP5_Amon	      |
+rsuscs	       | swup_sfc_clr	| T2?s		|	| CMIP5_Amon	      |
+rsut	       | swup_toa	| T2?s		|	| CMIP5_Amon	      |
+rsutcs	       | swup_toa_clr	| T2?s		|	| CMIP5_Amon	      |
+rtmt	       | netrad_toa_1_Pa| T2?s		|	| CMIP5_Amon	      |
 snd	       | #RECIP		| T2?s		|	| 		      |
+ta	       | temp		| T3?,T2?z	|	| CMIP5_Amon	      |
 tas            | t_ref          | T2?s          |       | CMIP5_Amon          |
+tro3	       | O3		| T3?,T2?z	|	| 		      |
 ts             | t_surf         | T2?s          |       | CMIP5_Amon          |
 ua             | ucomp          | T3?,T2?z      |       | CMIP5_Amon          |
 va             | vcomp          | T3?,T2?z      |       | CMIP5_Amon          |
+vmrc2h4	       | C2H4		| T3?,T2?z	|	| CMIP5_Amon	      |
+vmrc2h6	       | C2H6		| T3?,T2?z	|	| CMIP5_Amon	      |
+vmrc3h6	       | C3H6		| T3?,T2?z	|	| CMIP5_Amon	      |
+vmrc3h8	       | C3H8		| T3?,T2?z	|	| CMIP5_Amon	      |
+vmrch3coch3    | CH3COCH3	| T3?,T2?z	|	| CMIP5_Amon	      |
+vmrco	       | CO		| T3?,T2?z	|	| CMIP5_Amon	      |
+vmrnox	       | #RECIP		| T3?,T2?z	|	| CMIP5_Amon	      |
+vmro3	       | #RECIP		| T3?,T2?z	|	| CMIP5_Amon	      |
+zg	       | hght		| T3?,T2?z	|	| CMIP5_Amon	      |

--- a/reformat_scripts/GFDL/recipes/GFDL_recipe_vmrnox.ncl
+++ b/reformat_scripts/GFDL/recipes/GFDL_recipe_vmrnox.ncl
@@ -1,0 +1,19 @@
+;;#############################################################################
+;; Recipe to extract a complex variable from EMAC output
+;;#############################################################################
+;;
+;; VARIABLE: vmrnox
+;; RECIPE:   NO + NO2
+;; HISTORY:  20140424-A_righ_ma: written.
+;; 	     20160210-maso_er: ported to GFDL.
+;;#############################################################################
+load "./interface_scripts/constants.ncl"
+undef("GFDL_recipe")
+function GFDL_recipe(name: string)
+begin
+
+    xx = find_and_read_var("NO", True)
+    xx = xx + find_and_read_var("NO2", True)
+    return(xx)
+
+end

--- a/reformat_scripts/GFDL/recipes/GFDL_recipe_vmro3.ncl
+++ b/reformat_scripts/GFDL/recipes/GFDL_recipe_vmro3.ncl
@@ -1,0 +1,26 @@
+;;########################################################################
+;; Recipe to extract a complex variable from GFDL output
+;;########################################################################
+;;
+;; VARIABLE: vmro3
+;; RECIPE: O3 -> units to plev
+;; HISTORY: 20160112-maso_er: written.
+;;
+;;########################################################################
+
+load "./interface_scripts/constants.ncl"
+undef("GFDL_recipe")
+function GFDL_recipe(name: string)
+local vmro3
+begin
+
+  ;; Read in the data
+  vmro3 = find_and_read_var("O3", True)
+
+  ;; Rename the units for pfull
+  vmro3!1 = "plev"
+
+  ;; Return the vmro3 values
+  return(vmro3)
+
+end

--- a/reformat_scripts/GFDL/reformat_GFDL_func.ncl
+++ b/reformat_scripts/GFDL/reformat_GFDL_func.ncl
@@ -124,6 +124,8 @@ end
 ;;#############################################################################
 undef("find_and_read_var")
 function find_and_read_var(var:string,
+		           year1:integer,
+			   year2:integer,
                            err:logical)
 ;;
 ;; Arguments
@@ -154,6 +156,7 @@ begin
     ;; Define files list
     ;; Naming convention: <REALM>.<YYYYMM>-<YYYYMM>.<VAR>.nc
     flist = systemfunc("find " + INPATH + " -type f -name '" + REALM + "." + \
+    	    	       sprinti( "%0.4i", year1 ) + "*-" + sprinti( "%0.4i", year2 ) + \
                        "*." + var + ".nc' 2>/dev/null")
 
     ;; If all missing: give up
@@ -389,7 +392,7 @@ begin
 
     ;; Read variable
     if (name.ne."#RECIP") then  ; GFDL variable
-        xx = find_and_read_var(name, True)
+        xx = find_and_read_var(name, year1, year2, True)
     else
         if (isfilepresent_esmval(RECIPEFILE)) then
             xx = GFDL_recipe(name)  ; complex variable
@@ -410,8 +413,14 @@ begin
 
     ;; Extract given time range
     date = cd_calendar(xz&time, -1)
-    idx1 = ind(date.eq.(100 * year1 + 1))
-    idx2 = ind(date.eq.(100 * year2 + 12))
+; maso_er+ -- only one file being used at GFDL so this is 'safe'
+;    idx1 = (ind(date.eq.(100 * year1 + 1)))
+;    idx2 = (ind(date.eq.(100 * year2 + 12)))
+     idx1 =  0
+     idx2 = dimsizes(date)-1
+     
+; maso_er-
+
 
     if (ismissing(idx1).or.ismissing(idx2)) then
         error_msg("f", "reformat_GFDL_func.ncl", funcname, \
@@ -474,6 +483,9 @@ begin
             if (var&time@calendar.eq."NOLEAP") then
                 var&time@calendar = "noleap"
             end if
+	    if (var&time@calendar.eq."JULIAN") then
+	        var&time@calendar = "standard"
+	    end if
         end if
         if (isatt(var&time, "calendar")) then
             if (var&time@calendar.ne."standard".and.\
@@ -512,7 +524,7 @@ begin
     end if
 
     ;; Level
-    if (iscoord(var, "level")) then
+    if (iscoord(var, "level").or.iscoord(var, "pfull")) then
         var!1 = "plev"
         var&plev = var&plev * 100  ; [hPa] --> [Pa]
         ;; Check ordering (must be monotonically decreasing)

--- a/reformat_scripts/recognized_units.dat
+++ b/reformat_scripts/recognized_units.dat
@@ -24,22 +24,22 @@ std_unit = %
 alt_unit = %/100,100, 1,100
 
 std_unit = W m-2
-alt_unit = W/m**2,1, W/m2,1
+alt_unit = W/m**2,1, W/m2,1, watts/m2,1
 
 std_unit = 1
 alt_unit = kg/kg,1, kg kg-1,1
 
 std_unit = mole mole-1
-alt_unit = 1e-6,1.e-6, 1e-9,1.e-9, 1e-12,1.e-12, ppm,1.e-6, ppb,1.e-9, ppt,1.e-12, mol/mol,1, mol mol-1,1, mole mole^-1,1
+alt_unit = 1e-6,1.e-6, 1e-9,1.e-9, 1e-12,1.e-12, ppm,1.e-6, ppb,1.e-9, ppt,1.e-12, mol/mol,1, mol mol-1,1, mole mole^-1,1, vmr,1
 
 std_unit = 1e-9
-alt_unit = ppb,1, mol/mol,1.e9
+alt_unit = ppb,1, mol/mol,1.e9, vmr,1.e9
 
 std_unit = DU
 alt_unit = mg m-2, 4.6707e-2, g m-2, 4.6707e-5, kg m-2, 4.6707e-8, mmol m-2, 2.2414, mol m-2, 2.2414e-3 
 
 std_unit = kg m-2 s-1
-alt_unit = kg /(m^2 s),1, kg/(m^2 * s),1, kg/m**2s,1, mol m-2 s-1,0.012, g*m-2*d-1,1.16e-8, kgC/m2/h,2.78e-4, kg/m2/s,1
+alt_unit = kg /(m^2 s),1, kg/(m^2 * s),1, kg/m**2s,1, mol m-2 s-1,0.012, g*m-2*d-1,1.16e-8, kgC/m2/h,2.78e-4, kg/m2/s,1, kg(h2o)/m2/s,1
 
 std_unit = mm d-1
 alt_unit = mm/d,1

--- a/reformat_scripts/recognized_vars.dat
+++ b/reformat_scripts/recognized_vars.dat
@@ -17,7 +17,7 @@ std_name = time
 alt_name = t
 
 std_name = plev
-alt_name = p,plevs,lev_p
+alt_name = p,plevs,lev_p,pfull
 
 std_name = lev
 alt_name = 


### PR DESCRIPTION
The additions in this pull request are needed to run ESMValTool within the GFDL post-processing workflow. Merging these changes in will ease transitions to all subsequent releases of ESMValTool.

<b> Notes regarding some of the changes in this pull request:</b>
- GFDL_UDA project - This project will allow scientists at NOAA's GFDL in Princeton, NJ, USA to work with all CMIP5 data that has been downloaded into their Unified Data Archive (UDA). All the data from the UDA has been downloaded from the ESGF using the synda download utility (formerly known as synchro_data).
- Some of the changes to reformat_GFDL_func.ncl are to support the frequency and time-format of the GFDL post-processed files that ESMValTool is being run on. 